### PR TITLE
[SDK 5.0.1] Adds support for SDK version 5.0.1 and make install/uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ no_xselectinput.so: no_xselectinput.c
 	
 install:
 	cp oculus_wine_wrapper.sh $(INSTALL_PATH)/bin/oculus-wine-wrapper.sh
+	ln -s $(INSTALL_PATH)/bin/oculus-wine-wrapper.sh $(INSTALL_PATH)/bin/oculus-wine-wrapper
 	mkdir $(INSTALL_PATH)/lib/oculus-wine-wrapper/
 	cp no_xselectinput.so $(INSTALL_PATH)/lib/oculus-wine-wrapper/no_xselectinput.so
 	cp oculus_shm_adapter.exe $(INSTALL_PATH)/lib/oculus-wine-wrapper/oculus_shm_adapter.exe

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 MINGW_PFX = i686-w64-mingw32
+INSTALL_PATH?=/usr/local
 
 .DUMMY: all
 
@@ -12,3 +13,12 @@ oculus_shm_adapter.exe: oculus_shm_adapter.c
 no_xselectinput.so: no_xselectinput.c
 	gcc $< -o $@ -shared -fPIC -Os
 	strip --strip-unneeded $@
+	
+install:
+	cp oculus_wine_wrapper.sh $INSTALL_PATH/bin
+	cp no_xselectinput.so $INSTALL_PATH/lib/oculus-wine-wrapper
+	cp oculus_shm_adapter.exe $INSTALL_PATH/lib/oculus-wine-wrapper
+	
+uninstall:
+	rm -f $INSTALL_PATH/bin/oculus-wine-wrapper.sh
+	rm -rf $INSTALL_PATH/lib/oculus-wine-wrapper

--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,6 @@ install:
 	cp oculus_shm_adapter.exe $(INSTALL_PATH)/lib/oculus-wine-wrapper/oculus_shm_adapter.exe
 	
 uninstall:
+	rm -f $(INSTALL_PATH)/bin/oculus-wine-wrapper
 	rm -f $(INSTALL_PATH)/bin/oculus-wine-wrapper.sh
 	rm -rf $(INSTALL_PATH)/lib/oculus-wine-wrapper

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,11 @@ no_xselectinput.so: no_xselectinput.c
 	strip --strip-unneeded $@
 	
 install:
-	cp oculus_wine_wrapper.sh $INSTALL_PATH/bin
-	cp no_xselectinput.so $INSTALL_PATH/lib/oculus-wine-wrapper
-	cp oculus_shm_adapter.exe $INSTALL_PATH/lib/oculus-wine-wrapper
+	cp oculus_wine_wrapper.sh $(INSTALL_PATH)/bin/oculus-wine-wrapper.sh
+	mkdir $(INSTALL_PATH)/lib/oculus-wine-wrapper/
+	cp no_xselectinput.so $(INSTALL_PATH)/lib/oculus-wine-wrapper/no_xselectinput.so
+	cp oculus_shm_adapter.exe $(INSTALL_PATH)/lib/oculus-wine-wrapper/oculus_shm_adapter.exe
 	
 uninstall:
-	rm -f $INSTALL_PATH/bin/oculus-wine-wrapper.sh
-	rm -rf $INSTALL_PATH/lib/oculus-wine-wrapper
+	rm -f $(INSTALL_PATH)/bin/oculus-wine-wrapper.sh
+	rm -rf $(INSTALL_PATH)/lib/oculus-wine-wrapper

--- a/oculus_shm_adapter.c
+++ b/oculus_shm_adapter.c
@@ -33,7 +33,7 @@ int main(int argc, char** argv) {
     HANDLE ffhandle;
     printf("Oculus Rift shared memory adapter for Wine\n");
     printf("(C) 2014 Jared Stafford (jspenguin@jspenguin.org)\n");
-    printf("Source available at https://jspenguin.org/software/ovrsdk/\n\n");
+    printf("Source available at https://github.com/jspenguin/oculus-wine-wrapper/\n\n");
     if (chdir("/dev/shm") != 0) {
         printf("Could not change directory to /dev/shm: %s\n", strerror(errno));
         return 1;

--- a/oculus_wine_wrapper.sh
+++ b/oculus_wine_wrapper.sh
@@ -45,16 +45,16 @@ if [ -z $OCULUSD ]; then
 	OCULUSD=/usr/bin/oculusd
 	
 	# Check alternate v4 path
-	if [ -f /opt/oculus/bin/oculusd ]
+	if [ -f /opt/oculus/bin/oculusd ]; then
 		OCULUSD=/opt/oculus/bin/oculusd
 	fi
 	
 	# Check v5 paths
-	if [ -f /usr/bin/ovrd ]
+	if [ -f /usr/bin/ovrd ]; then
     	OCULUSD=/usr/bin/oculusd
 	fi
 			
-	if [ -f /opt/oculus/bin/ovrd ]
+	if [ -f /opt/oculus/bin/ovrd ]; then
 		OCULUSD=/opt/oculus/bin/ovrd
 	fi
 fi

--- a/oculus_wine_wrapper.sh
+++ b/oculus_wine_wrapper.sh
@@ -60,7 +60,7 @@ if [ -z $OCULUSD ]; then
 fi
 
 if [ -z $UTILSDIR ]; then
-	UTILSDIR=/usr/share/oculus-wine-wrapper
+	UTILSDIR=/usr/lib/oculus-wine-wrapper
 fi
 
 if [ ! -x $OCULUSD ]; then
@@ -77,7 +77,7 @@ if [ $# -lt 1 ]; then
     echo "Usage: $0 [options] /path/to/game.exe [arguments]"
 	echo "$0 options:"
 	echo "  -o, --oculusd       specify location of oculusd or ovrd (default /usr/bin/oculusd)"
-	echo "  -u, --utilsdir      specify location of wrapper utilities (default /usr/share/oculus-wine-wrapper)"
+	echo "  -u, --utilsdir      specify location of wrapper utilities (default /usr/lib/oculus-wine-wrapper)"
 	echo "  -r, --norestart     don't re-execute oculusd after game exits"
 	echo "  -k, --nokill        don't kill running oculusd service"
     exit 1

--- a/oculus_wine_wrapper.sh
+++ b/oculus_wine_wrapper.sh
@@ -51,7 +51,7 @@ if [ -z $OCULUSD ]; then
 	
 	# Check v5 paths
 	if [ -f /usr/bin/ovrd ]; then
-    	OCULUSD=/usr/bin/oculusd
+		OCULUSD=/usr/bin/oculusd
 	fi
 			
 	if [ -f /opt/oculus/bin/ovrd ]; then

--- a/oculus_wine_wrapper.sh
+++ b/oculus_wine_wrapper.sh
@@ -37,8 +37,26 @@ while [[ ${1:0:1} = "-" ]]; do
 	shift
 done
 
+# Check for OVR v4 and v5 SDK installs.
+# v4 names the service oculusd, and v5 names the service ovrd.
+# Additionally, it is on occasion popular to install the service to /opt/oculus.
 if [ -z $OCULUSD ]; then
-    OCULUSD=/usr/bin/oculusd
+	# Set default
+	OCULUSD=/usr/bin/oculusd
+	
+	# Check alternate v4 path
+	if [ -f /opt/oculus/bin/oculusd ]
+		OCULUSD=/opt/oculus/bin/oculusd
+	fi
+	
+	# Check v5 paths
+	if [ -f /usr/bin/ovrd ]
+    	OCULUSD=/usr/bin/oculusd
+	fi
+			
+	if [ -f /opt/oculus/bin/ovrd ]
+		OCULUSD=/opt/oculus/bin/ovrd
+	fi
 fi
 
 if [ -z $UTILSDIR ]; then
@@ -58,7 +76,7 @@ fi
 if [ $# -lt 1 ]; then
     echo "Usage: $0 [options] /path/to/game.exe [arguments]"
 	echo "$0 options:"
-	echo "  -o, --oculusd       specify location of oculusd (default /usr/bin/oculusd)"
+	echo "  -o, --oculusd       specify location of oculusd or ovrd (default /usr/bin/oculusd)"
 	echo "  -u, --utilsdir      specify location of wrapper utilities (default /usr/share/oculus-wine-wrapper)"
 	echo "  -r, --norestart     don't re-execute oculusd after game exits"
 	echo "  -k, --nokill        don't kill running oculusd service"


### PR DESCRIPTION
Here's a few quality of life additions as well as support for the final 5.0.1 version of the Linux SDK.

Summary of changes:

- Added an install target to the Makefile. The target installs the script to $INSTALL_PATH/bin and the utilities to $INSTALL_PATH/lib/oculus-wine-wrapper in compliance with usual *nix directory structure.
- Added an uninstall target to the Makefile that completely reverts the install command.
- Added support for the new name of the oculus service (ovrd).
- Added support for another very common installation path (/opt/oculus)